### PR TITLE
perf: Add a lazy variant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ all-features = true
 
 [dependencies]
 url = "2.1.1"
-serde = { version = "1.0.104", features = ["derive"] }
+serde = { version = "1.0.104", features = ["derive", "rc"] }
 serde_json = { version = "1.0.48", features = ["raw_value"] }
 unicode-id-start = "1"
 if_chain = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ all-features = true
 [dependencies]
 url = "2.1.1"
 serde = { version = "1.0.104", features = ["derive"] }
-serde_json = "1.0.48"
+serde_json = { version = "1.0.48", features = ["raw_value"] }
 unicode-id-start = "1"
 if_chain = "1.0.0"
 scroll = { version = "0.12.0", features = ["derive"], optional = true }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -124,7 +124,7 @@ pub fn strip_junk_header(slice: &[u8]) -> io::Result<&[u8]> {
 }
 
 /// Decodes range mappping bitfield string into index
-fn decode_rmi(rmi_str: &str, val: &mut BitVec<u8, Lsb0>) -> Result<()> {
+pub(crate) fn decode_rmi(rmi_str: &str, val: &mut BitVec<u8, Lsb0>) -> Result<()> {
     val.clear();
     val.resize(rmi_str.len() * 6, false);
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -20,11 +20,11 @@ pub fn encode<M: Encodable, W: Write>(sm: &M, mut w: W) -> Result<()> {
     Ok(())
 }
 
-fn encode_vlq_diff(out: &mut String, a: u32, b: u32) {
+pub(crate) fn encode_vlq_diff(out: &mut String, a: u32, b: u32) {
     encode_vlq(out, i64::from(a) - i64::from(b))
 }
 
-fn encode_rmi(out: &mut Vec<u8>, data: &[u8]) {
+pub(crate) fn encode_rmi(out: &mut Vec<u8>, data: &[u8]) {
     fn encode_byte(b: u8) -> u8 {
         match b {
             0..=25 => b + b'A',

--- a/src/lazy/mod.rs
+++ b/src/lazy/mod.rs
@@ -29,11 +29,11 @@ pub struct RawSourceMap<'a> {
     pub(crate) sources: MaybeRawValue<'a, Vec<StrValue<'a>>>,
     #[serde(default, borrow)]
     pub(crate) source_root: Option<StrValue<'a>>,
-    #[serde(borrow)]
+    #[serde(default, borrow)]
     pub(crate) sources_content: MaybeRawValue<'a, Vec<Option<StrValue<'a>>>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) sections: Option<Vec<RawSection<'a>>>,
-    #[serde(borrow)]
+    #[serde(default, borrow)]
     pub(crate) names: MaybeRawValue<'a, Vec<StrValue<'a>>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) range_mappings: Option<String>,

--- a/src/lazy/mod.rs
+++ b/src/lazy/mod.rs
@@ -3,10 +3,12 @@
 use crate::{
     decoder::{decode_rmi, strip_junk_header},
     encoder::{encode_rmi, encode_vlq_diff},
+    types::adjust_mappings,
     vlq::parse_vlq_segment_into,
     Error, RawToken, Result,
 };
 use std::{
+    borrow::Cow,
     collections::{BTreeSet, HashMap},
     sync::Arc,
 };
@@ -412,113 +414,10 @@ pub fn decode_regular(rsm: RawSourceMap) -> Result<SourceMap> {
 impl<'a> SourceMap<'a> {
     /// Refer to [crate::SourceMap::adjust_mappings] for more details.
     pub fn adjust_mappings(&mut self, adjustment: crate::SourceMap) {
-        // Helper struct that makes it easier to compare tokens by the start and end
-        // of the range they cover.
-        #[derive(Debug, Clone, Copy)]
-        struct Range<'a> {
-            start: (u32, u32),
-            end: (u32, u32),
-            value: &'a RawToken,
-        }
-
-        /// Turns a list of tokens into a list of ranges, using the provided `key` function to
-        /// determine the order of the tokens.
-        #[allow(clippy::ptr_arg)]
-        fn create_ranges(
-            tokens: &mut [RawToken],
-            key: fn(&RawToken) -> (u32, u32),
-        ) -> Vec<Range<'_>> {
-            tokens.sort_unstable_by_key(key);
-
-            let mut token_iter = tokens.iter().peekable();
-            let mut ranges = Vec::new();
-
-            while let Some(t) = token_iter.next() {
-                let start = key(t);
-                let next_start = token_iter.peek().map_or((u32::MAX, u32::MAX), |t| key(t));
-                // A token extends either to the start of the next token or the end of the line,
-                // whichever comes sooner
-                let end = std::cmp::min(next_start, (start.0, u32::MAX));
-                ranges.push(Range {
-                    start,
-                    end,
-                    value: t,
-                });
-            }
-
-            ranges
-        }
-
-        // Turn `self.tokens` and `adjustment.tokens` into vectors of ranges so we have easy access
-        // to both start and end.
-        // We want to compare `self` and `adjustment` tokens by line/column numbers in the "original
-        // source" file. These line/column numbers are the `dst_line/col` for
-        // the `self` tokens and `src_line/col` for the `adjustment` tokens.
-        let mut self_tokens = std::mem::take(&mut self.tokens);
-        let original_ranges = create_ranges(&mut self_tokens, |t| (t.dst_line, t.dst_col));
-        let mut adjustment_tokens = adjustment.tokens.clone();
-        let adjustment_ranges = create_ranges(&mut adjustment_tokens, |t| (t.src_line, t.src_col));
-
-        let mut original_ranges_iter = original_ranges.iter();
-
-        let mut original_range = match original_ranges_iter.next() {
-            Some(r) => r,
-            None => return,
-        };
-
-        // Iterate over `adjustment_ranges` (sorted by `src_line/col`). For each such range,
-        // consider all `original_ranges` which overlap with it.
-        'outer: for &adjustment_range in &adjustment_ranges {
-            // The `adjustment_range` offsets lines and columns by a certain amount. All
-            // `original_ranges` it covers will get the same offset.
-            let (line_diff, col_diff) = (
-                adjustment_range.value.dst_line as i32 - adjustment_range.value.src_line as i32,
-                adjustment_range.value.dst_col as i32 - adjustment_range.value.src_col as i32,
-            );
-
-            // Skip `original_ranges` that are entirely before the `adjustment_range`.
-            while original_range.end <= adjustment_range.start {
-                match original_ranges_iter.next() {
-                    Some(r) => original_range = r,
-                    None => break 'outer,
-                }
-            }
-
-            // At this point `original_range.end` > `adjustment_range.start`
-
-            // Iterate over `original_ranges` that fall at least partially within the
-            // `adjustment_range`.
-            while original_range.start < adjustment_range.end {
-                // If `original_range` started before `adjustment_range`, cut off the token's start.
-                let (dst_line, dst_col) =
-                    std::cmp::max(original_range.start, adjustment_range.start);
-                let mut token = RawToken {
-                    dst_line,
-                    dst_col,
-                    ..*original_range.value
-                };
-
-                token.dst_line = (token.dst_line as i32 + line_diff) as u32;
-                token.dst_col = (token.dst_col as i32 + col_diff) as u32;
-
-                self.tokens.push(token);
-
-                if original_range.end >= adjustment_range.end {
-                    // There are surely no more `original_ranges` for this `adjustment_range`.
-                    // Break the loop without advancing the `original_range`.
-                    break;
-                } else {
-                    //  Advance the `original_range`.
-                    match original_ranges_iter.next() {
-                        Some(r) => original_range = r,
-                        None => break 'outer,
-                    }
-                }
-            }
-        }
-
-        self.tokens
-            .sort_unstable_by_key(|t| (t.dst_line, t.dst_col));
+        self.tokens = adjust_mappings(
+            std::mem::take(&mut self.tokens),
+            Cow::Owned(adjustment.tokens),
+        );
     }
 
     pub fn into_raw_sourcemap(self) -> RawSourceMap<'a> {

--- a/src/lazy/mod.rs
+++ b/src/lazy/mod.rs
@@ -410,49 +410,8 @@ pub fn decode_regular(rsm: RawSourceMap) -> Result<SourceMap> {
 }
 
 impl<'a> SourceMap<'a> {
-    /// Adjusts the mappings in `self` using the mappings in `adjustment`.
-    ///
-    /// Here is the intended use case for this function:
-    /// * You have a source file (for example, minified JS) `foo.js` and a corresponding sourcemap
-    ///   `foo.js.map`.
-    /// * You modify `foo.js` in some way and generate a sourcemap `transform.js.map` representing
-    ///   this modification. This can be done using `magic-string`, for example.
-    /// * You want a sourcemap that is "like" `foo.js.map`, but takes the changes you made to
-    ///   `foo.js` into account.
-    ///
-    /// Then `foo.js.map.adjust_mappings(transform.js.map)` is the desired sourcemap.
-    ///
-    /// This function assumes that `adjustment` contains no relevant information except for
-    /// mappings.  All information about sources and names is copied from `self`.
-    ///
-    /// Note that the resulting sourcemap will be at most as fine-grained as `self.`.
+    /// Refer to [crate::SourceMap::adjust_mappings] for more details.
     pub fn adjust_mappings(&mut self, adjustment: crate::SourceMap) {
-        // The algorithm works by going through the tokens in `self` in order and adjusting
-        // them depending on the token in `adjustment` they're "covered" by.
-        // For example:
-        // Let `l` be a token in `adjustment` mapping `(17, 23)` to `(8, 30)` and let
-        // `r₁ : (8, 28) -> (102, 35)`, `r₂ : (8, 40) -> (102, 50)`, and
-        // `r₃ : (9, 10) -> (103, 12)` be the tokens in `self` that fall in the range of `l`.
-        // `l` offsets these tokens by `(+9, -7)`, so `r₁, … , r₃` must be offset by the same
-        // amount. Thus, the adjusted sourcemap will contain the tokens
-        // `c₁ : (17, 23) -> (102, 35)`, `c₂ : (17, 33) -> (102, 50)`, and
-        // `c3 : (18, 3) -> (103, 12)`.
-        //
-        // Or, in diagram form:
-        //
-        //    (17, 23)                                    (position in the edited source file)
-        //    ↓ l
-        //    (8, 30)
-        // (8, 28)        (8, 40)        (9, 10)          (positions in the original source file)
-        // ↓ r₁           ↓ r₂           ↓ r₃
-        // (102, 35)      (102, 50)      (103, 12)        (positions in the target file)
-        //
-        // becomes
-        //
-        //    (17, 23)       (17, 33)       (18, 3)       (positions in the edited source file)
-        //    ↓ c₁           ↓ c₂           ↓ c₃
-        //    (102, 35)      (102, 50)      (103, 12)     (positions in the target file)
-
         // Helper struct that makes it easier to compare tokens by the start and end
         // of the range they cover.
         #[derive(Debug, Clone, Copy)]

--- a/src/lazy/mod.rs
+++ b/src/lazy/mod.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct RawSourceMap<'a> {
     pub(crate) version: Option<u32>,
     #[serde(default, borrow)]

--- a/src/lazy/mod.rs
+++ b/src/lazy/mod.rs
@@ -1,8 +1,4 @@
-//! This is forked from rust-sourcemap crate.
-//!
-//! https://github.com/getsentry/rust-sourcemap/tree/696899f4ca92f1fc133237c74ca1a54cf7448e49
-//!
-//! We skip deserializing all the fields that we don't need. (unlike the original crate)
+//! This is _lazy_ because we skip deserializing all the fields that we don't need. (unlike the original crate)
 
 use crate::{
     decoder::{decode_rmi, strip_junk_header},

--- a/src/lazy/mod.rs
+++ b/src/lazy/mod.rs
@@ -433,7 +433,7 @@ impl<'a> SourceMap<'a> {
     /// mappings.  All information about sources and names is copied from `self`.
     ///
     /// Note that the resulting sourcemap will be at most as fine-grained as `self.`.
-    pub fn adjust_mappings(&mut self, adjustment: Self) {
+    pub fn adjust_mappings(&mut self, adjustment: crate::SourceMap) {
         // The algorithm works by going through the tokens in `self` in order and adjusting
         // them depending on the token in `adjustment` they're "covered" by.
         // For example:
@@ -768,29 +768,4 @@ fn serialize_mappings(sm: &SourceMap) -> String {
     }
 
     rv
-}
-
-impl From<crate::SourceMap> for SourceMap<'_> {
-    fn from(value: crate::SourceMap) -> Self {
-        SourceMap {
-            file: value.file.map(MaybeRawValue::Data),
-            tokens: value.tokens,
-            names: MaybeRawValue::Data(value.names.into_iter().map(MaybeRawValue::Data).collect()),
-            source_root: value.source_root.map(MaybeRawValue::Data),
-            sources: MaybeRawValue::Data(
-                value.sources.into_iter().map(MaybeRawValue::Data).collect(),
-            ),
-            sources_prefixed: value
-                .sources_prefixed
-                .map(|v| MaybeRawValue::Data(v.into_iter().map(MaybeRawValue::Data).collect())),
-            sources_content: MaybeRawValue::Data(
-                value
-                    .sources_content
-                    .into_iter()
-                    .map(|v| v.map(|v| v.source).map(MaybeRawValue::Data))
-                    .collect(),
-            ),
-            ignore_list: Some(MaybeRawValue::Data(value.ignore_list)),
-        }
-    }
 }

--- a/src/lazy/mod.rs
+++ b/src/lazy/mod.rs
@@ -201,37 +201,10 @@ impl<'a> SourceMapBuilder<'a> {
         self.source_contents[src_id as usize] = contents.map(MaybeRawValue::RawValue);
     }
 
-    pub fn add_raw_token(
-        &mut self,
-        dst_line: u32,
-        dst_col: u32,
-        src_line: u32,
-        src_col: u32,
-        src_id: Option<u32>,
-        name_id: Option<u32>,
-        is_range: bool,
-    ) -> RawToken {
-        let token = RawToken {
-            dst_line,
-            dst_col,
-            src_line,
-            src_col,
-            src_id: src_id.unwrap_or(!0), // Use !0 as sentinel for None, common in sourcemap crate
-            name_id: name_id.unwrap_or(!0),
-            is_range,
-        };
-        self.tokens.push(token);
-        token
-    }
-
     pub fn add_to_ignore_list(&mut self, src_id: u32) {
         self.ignore_list
             .get_or_insert_with(BTreeSet::new)
             .insert(src_id);
-    }
-
-    pub fn set_source_root(&mut self, source_root: Option<StrValue<'a>>) {
-        self.source_root = source_root;
     }
 
     pub fn into_sourcemap(self) -> SourceMap<'a> {
@@ -300,24 +273,9 @@ impl<'a> SourceMapSection<'a> {
         }
     }
 
-    /// Returns the offset line
-    pub fn get_offset_line(&self) -> u32 {
-        self.offset.0
-    }
-
-    /// Returns the offset column
-    pub fn get_offset_col(&self) -> u32 {
-        self.offset.1
-    }
-
     /// Returns the offset as tuple
     pub fn get_offset(&self) -> (u32, u32) {
         self.offset
-    }
-
-    /// Updates the URL for this section.
-    pub fn set_url(&mut self, value: Option<&str>) {
-        self.url = value.map(str::to_owned).map(MaybeRawValue::Data);
     }
 }
 

--- a/src/lazy/mod.rs
+++ b/src/lazy/mod.rs
@@ -135,7 +135,6 @@ pub struct SourceMap<'a> {
     names: MaybeRawValue<'a, Vec<StrValue<'a>>>,
     source_root: Option<StrValue<'a>>,
     sources: MaybeRawValue<'a, Vec<StrValue<'a>>>,
-    sources_prefixed: Option<MaybeRawValue<'a, Vec<StrValue<'a>>>>,
     sources_content: MaybeRawValue<'a, Vec<Option<StrValue<'a>>>>,
     ignore_list: Option<MaybeRawValue<'a, BTreeSet<u32>>>,
 }
@@ -214,7 +213,6 @@ impl<'a> SourceMapBuilder<'a> {
             names: MaybeRawValue::Data(self.names),
             source_root: self.source_root,
             sources: MaybeRawValue::Data(self.sources),
-            sources_prefixed: None,
             sources_content: MaybeRawValue::Data(self.source_contents),
             ignore_list: self.ignore_list.map(MaybeRawValue::Data),
         }
@@ -408,7 +406,6 @@ pub fn decode_regular(rsm: RawSourceMap) -> Result<SourceMap> {
         names: rsm.names,
         source_root: rsm.source_root,
         sources: rsm.sources,
-        sources_prefixed: None,
         sources_content: rsm.sources_content,
         ignore_list: rsm.ignore_list,
     };

--- a/src/lazy/mod.rs
+++ b/src/lazy/mod.rs
@@ -1,0 +1,885 @@
+//! This is forked from rust-sourcemap crate.
+//!
+//! https://github.com/getsentry/rust-sourcemap/tree/696899f4ca92f1fc133237c74ca1a54cf7448e49
+//!
+//! We skip deserializing all the fields that we don't need. (unlike the original crate)
+
+use crate::{vlq::parse_vlq_segment_into, Error, RawToken, Result};
+use std::{
+    collections::{BTreeSet, HashMap},
+    io,
+};
+
+use bitvec::{field::BitField, order::Lsb0, vec::BitVec, view::BitView};
+use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RawSourceMap<'a> {
+    pub(crate) version: Option<u32>,
+    #[serde(default, borrow)]
+    pub(crate) file: Option<&'a RawValue>,
+    #[serde(borrow)]
+    pub(crate) sources: MaybeRawValue<'a, Vec<&'a RawValue>>,
+    #[serde(default, borrow)]
+    pub(crate) source_root: Option<&'a RawValue>,
+    #[serde(borrow)]
+    pub(crate) sources_content: MaybeRawValue<'a, Vec<Option<&'a RawValue>>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) sections: Option<Vec<RawSection<'a>>>,
+    #[serde(borrow)]
+    pub(crate) names: MaybeRawValue<'a, Vec<&'a RawValue>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) range_mappings: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) mappings: Option<String>,
+    #[serde(default, borrow)]
+    pub(crate) ignore_list: Option<MaybeRawValue<'a, BTreeSet<u32>>>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Copy)]
+pub struct RawSectionOffset {
+    pub line: u32,
+    pub column: u32,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RawSection<'a> {
+    pub offset: RawSectionOffset,
+    #[serde(borrow)]
+    pub url: Option<&'a RawValue>,
+    #[serde(borrow)]
+    pub map: Option<&'a RawValue>,
+}
+
+#[derive(Debug)]
+pub enum DecodedMap<'a> {
+    Regular(SourceMap<'a>),
+    Index(SourceMapIndex<'a>),
+}
+
+impl<'a> DecodedMap<'a> {
+    pub fn into_source_map(self) -> Result<SourceMap<'a>> {
+        match self {
+            DecodedMap::Regular(source_map) => Ok(source_map),
+            DecodedMap::Index(source_map_index) => source_map_index.flatten(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum MaybeRawValue<'a, T> {
+    RawValue(#[serde(borrow)] &'a RawValue),
+    Data(T),
+}
+
+impl<'a, T> MaybeRawValue<'a, T>
+where
+    T: Deserialize<'a>,
+{
+    pub fn into_data(self) -> T {
+        match self {
+            MaybeRawValue::RawValue(s) => {
+                serde_json::from_str(s.get()).expect("Failed to convert RawValue to Data")
+            }
+            MaybeRawValue::Data(data) => data,
+        }
+    }
+}
+
+impl<T> Default for MaybeRawValue<'_, T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        MaybeRawValue::Data(T::default())
+    }
+}
+
+#[derive(Debug)]
+pub struct SourceMap<'a> {
+    file: Option<&'a RawValue>,
+    tokens: Vec<RawToken>,
+    names: MaybeRawValue<'a, Vec<&'a RawValue>>,
+    source_root: Option<&'a RawValue>,
+    sources: MaybeRawValue<'a, Vec<&'a RawValue>>,
+    sources_prefixed: Option<&'a RawValue>,
+    sources_content: MaybeRawValue<'a, Vec<Option<&'a RawValue>>>,
+    ignore_list: Option<MaybeRawValue<'a, BTreeSet<u32>>>,
+}
+
+#[derive(Debug)]
+pub struct SourceMapBuilder<'a> {
+    file: Option<&'a RawValue>,
+    name_map: HashMap<&'a str, u32>,
+    names: Vec<&'a RawValue>,
+    tokens: Vec<RawToken>,
+    source_map: HashMap<&'a str, u32>,
+    sources: Vec<&'a RawValue>,
+    source_contents: Vec<Option<&'a RawValue>>,
+    source_root: Option<&'a RawValue>,
+    ignore_list: Option<BTreeSet<u32>>,
+}
+
+impl<'a> SourceMapBuilder<'a> {
+    pub fn new(file: Option<&'a RawValue>) -> Self {
+        SourceMapBuilder {
+            file,
+            name_map: HashMap::new(),
+            names: Vec::new(),
+            tokens: Vec::new(),
+            source_map: HashMap::new(),
+            sources: Vec::new(),
+            source_contents: Vec::new(),
+            source_root: None,
+            ignore_list: None,
+        }
+    }
+
+    pub fn add_source(&mut self, src_raw: &'a RawValue) -> u32 {
+        let src_str = src_raw.get(); // RawValue provides get() -> &str
+        let count = self.sources.len() as u32;
+        let id = *self.source_map.entry(src_str).or_insert(count);
+        if id == count {
+            // New source
+            self.sources.push(src_raw);
+            // Ensure source_contents has a corresponding entry, defaulting to None.
+            // This logic ensures source_contents is always same length as sources if new one added.
+            self.source_contents.resize(self.sources.len(), None);
+        }
+        id
+    }
+
+    pub fn add_name(&mut self, name_raw: &'a RawValue) -> u32 {
+        let name_str = name_raw.get();
+        let count = self.names.len() as u32;
+        let id = *self.name_map.entry(name_str).or_insert(count);
+        if id == count {
+            // New name
+            self.names.push(name_raw);
+        }
+        id
+    }
+
+    pub fn set_source_contents(&mut self, src_id: u32, contents: Option<&'a RawValue>) {
+        // Ensure source_contents is large enough. src_id is 0-indexed.
+        if (src_id as usize) >= self.source_contents.len() {
+            self.source_contents.resize(src_id as usize + 1, None);
+        }
+        self.source_contents[src_id as usize] = contents;
+    }
+
+    pub fn add_raw_token(
+        &mut self,
+        dst_line: u32,
+        dst_col: u32,
+        src_line: u32,
+        src_col: u32,
+        src_id: Option<u32>,
+        name_id: Option<u32>,
+        is_range: bool,
+    ) -> RawToken {
+        let token = RawToken {
+            dst_line,
+            dst_col,
+            src_line,
+            src_col,
+            src_id: src_id.unwrap_or(!0), // Use !0 as sentinel for None, common in sourcemap crate
+            name_id: name_id.unwrap_or(!0),
+            is_range,
+        };
+        self.tokens.push(token);
+        token
+    }
+
+    pub fn add_to_ignore_list(&mut self, src_id: u32) {
+        self.ignore_list
+            .get_or_insert_with(BTreeSet::new)
+            .insert(src_id);
+    }
+
+    pub fn set_source_root(&mut self, source_root: Option<&'a RawValue>) {
+        self.source_root = source_root;
+    }
+
+    pub fn into_sourcemap(self) -> SourceMap<'a> {
+        SourceMap {
+            file: self.file,
+            tokens: self.tokens,
+            names: MaybeRawValue::Data(self.names),
+            source_root: self.source_root,
+            sources: MaybeRawValue::Data(self.sources),
+            sources_prefixed: None,
+            sources_content: MaybeRawValue::Data(self.source_contents),
+            ignore_list: self.ignore_list.map(MaybeRawValue::Data),
+        }
+    }
+
+    /// Adds a new mapping to the builder.
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_raw(
+        &mut self,
+        dst_line: u32,
+        dst_col: u32,
+        src_line: u32,
+        src_col: u32,
+        source: Option<u32>,
+        name: Option<u32>,
+        is_range: bool,
+    ) -> RawToken {
+        let src_id = source.unwrap_or(!0);
+        let name_id = name.unwrap_or(!0);
+        let raw = RawToken {
+            dst_line,
+            dst_col,
+            src_line,
+            src_col,
+            src_id,
+            name_id,
+            is_range,
+        };
+        self.tokens.push(raw);
+        raw
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct SourceMapSection<'a> {
+    offset: (u32, u32),
+    url: Option<MaybeRawValue<'a, String>>,
+    map: Option<Box<MaybeRawValue<'a, RawSourceMap<'a>>>>,
+}
+
+impl<'a> SourceMapSection<'a> {
+    /// Create a new sourcemap index section
+    ///
+    /// - `offset`: offset as line and column
+    /// - `url`: optional URL of where the sourcemap is located
+    /// - `map`: an optional already resolved internal sourcemap
+    pub fn new(
+        offset: (u32, u32),
+        url: Option<MaybeRawValue<'a, String>>,
+        map: Option<MaybeRawValue<'a, RawSourceMap<'a>>>,
+    ) -> SourceMapSection<'a> {
+        SourceMapSection {
+            offset,
+            url,
+            map: map.map(Box::new),
+        }
+    }
+
+    /// Returns the offset line
+    pub fn get_offset_line(&self) -> u32 {
+        self.offset.0
+    }
+
+    /// Returns the offset column
+    pub fn get_offset_col(&self) -> u32 {
+        self.offset.1
+    }
+
+    /// Returns the offset as tuple
+    pub fn get_offset(&self) -> (u32, u32) {
+        self.offset
+    }
+
+    /// Updates the URL for this section.
+    pub fn set_url(&mut self, value: Option<&str>) {
+        self.url = value.map(str::to_owned).map(MaybeRawValue::Data);
+    }
+}
+
+#[derive(Debug)]
+pub struct SourceMapIndex<'a> {
+    file: Option<&'a RawValue>,
+    sections: Vec<SourceMapSection<'a>>,
+}
+
+pub fn decode(slice: &[u8]) -> Result<DecodedMap> {
+    let content = strip_junk_header(slice)?;
+    let rsm: RawSourceMap = serde_json::from_slice(content)?;
+
+    decode_common(rsm)
+}
+
+fn decode_common(rsm: RawSourceMap) -> Result<DecodedMap> {
+    if rsm.sections.is_some() {
+        decode_index(rsm).map(DecodedMap::Index)
+    } else {
+        decode_regular(rsm).map(DecodedMap::Regular)
+    }
+}
+
+fn decode_index(rsm: RawSourceMap) -> Result<SourceMapIndex> {
+    let mut sections = vec![];
+
+    for raw_section in rsm.sections.unwrap_or_default() {
+        sections.push(SourceMapSection::new(
+            (raw_section.offset.line, raw_section.offset.column),
+            raw_section.url.map(MaybeRawValue::RawValue),
+            raw_section.map.map(MaybeRawValue::RawValue),
+        ));
+    }
+
+    sections.sort_by_key(SourceMapSection::get_offset);
+
+    // file sometimes is not a string for unexplicable reasons
+    let file = rsm.file;
+
+    Ok(SourceMapIndex { file, sections })
+}
+
+pub fn decode_regular(rsm: RawSourceMap) -> Result<SourceMap> {
+    let mut dst_col;
+
+    // Source IDs, lines, columns, and names are "running" values.
+    // Each token (except the first) contains the delta from the previous value.
+    let mut running_src_id = 0;
+    let mut running_src_line = 0;
+    let mut running_src_col = 0;
+    let mut running_name_id = 0;
+
+    let range_mappings = rsm.range_mappings.unwrap_or_default();
+    let mappings = rsm.mappings.unwrap_or_default();
+    let allocation_size = mappings.matches(&[',', ';'][..]).count() + 10;
+    let mut tokens = Vec::with_capacity(allocation_size);
+
+    let mut nums = Vec::with_capacity(6);
+    let mut rmi = BitVec::new();
+
+    for (dst_line, (line, rmi_str)) in mappings
+        .split(';')
+        .zip(range_mappings.split(';').chain(std::iter::repeat("")))
+        .enumerate()
+    {
+        if line.is_empty() {
+            continue;
+        }
+
+        dst_col = 0;
+
+        decode_rmi(rmi_str, &mut rmi)?;
+
+        for (line_index, segment) in line.split(',').enumerate() {
+            if segment.is_empty() {
+                continue;
+            }
+
+            nums.clear();
+            parse_vlq_segment_into(segment, &mut nums)?;
+            match nums.len() {
+                1 | 4 | 5 => {}
+                _ => return Err(Error::BadSegmentSize(nums.len() as u32)),
+            }
+
+            dst_col = (i64::from(dst_col) + nums[0]) as u32;
+
+            // The source file , source line, source column, and name
+            // may not be present in the current token. We use `u32::MAX`
+            // as the placeholder for missing values.
+            let mut current_src_id = !0;
+            let mut current_src_line = !0;
+            let mut current_src_col = !0;
+            let mut current_name_id = !0;
+
+            if nums.len() > 1 {
+                running_src_id = (i64::from(running_src_id) + nums[1]) as u32;
+
+                running_src_line = (i64::from(running_src_line) + nums[2]) as u32;
+                running_src_col = (i64::from(running_src_col) + nums[3]) as u32;
+
+                current_src_id = running_src_id;
+                current_src_line = running_src_line;
+                current_src_col = running_src_col;
+
+                if nums.len() > 4 {
+                    running_name_id = (i64::from(running_name_id) + nums[4]) as u32;
+                    current_name_id = running_name_id;
+                }
+            }
+
+            let is_range = rmi.get(line_index).map(|v| *v).unwrap_or_default();
+
+            tokens.push(RawToken {
+                dst_line: dst_line as u32,
+                dst_col,
+                src_line: current_src_line,
+                src_col: current_src_col,
+                src_id: current_src_id,
+                name_id: current_name_id,
+                is_range,
+            });
+        }
+    }
+
+    let sm = SourceMap {
+        file: rsm.file,
+        tokens,
+        names: rsm.names,
+        source_root: rsm.source_root,
+        sources: rsm.sources,
+        sources_prefixed: None,
+        sources_content: rsm.sources_content,
+        ignore_list: rsm.ignore_list,
+    };
+
+    Ok(sm)
+}
+
+impl<'a> SourceMap<'a> {
+    /// Adjusts the mappings in `self` using the mappings in `adjustment`.
+    ///
+    /// Here is the intended use case for this function:
+    /// * You have a source file (for example, minified JS) `foo.js` and a corresponding sourcemap
+    ///   `foo.js.map`.
+    /// * You modify `foo.js` in some way and generate a sourcemap `transform.js.map` representing
+    ///   this modification. This can be done using `magic-string`, for example.
+    /// * You want a sourcemap that is "like" `foo.js.map`, but takes the changes you made to
+    ///   `foo.js` into account.
+    ///
+    /// Then `foo.js.map.adjust_mappings(transform.js.map)` is the desired sourcemap.
+    ///
+    /// This function assumes that `adjustment` contains no relevant information except for
+    /// mappings.  All information about sources and names is copied from `self`.
+    ///
+    /// Note that the resulting sourcemap will be at most as fine-grained as `self.`.
+    pub fn adjust_mappings(&mut self, adjustment: Self) {
+        // The algorithm works by going through the tokens in `self` in order and adjusting
+        // them depending on the token in `adjustment` they're "covered" by.
+        // For example:
+        // Let `l` be a token in `adjustment` mapping `(17, 23)` to `(8, 30)` and let
+        // `r₁ : (8, 28) -> (102, 35)`, `r₂ : (8, 40) -> (102, 50)`, and
+        // `r₃ : (9, 10) -> (103, 12)` be the tokens in `self` that fall in the range of `l`.
+        // `l` offsets these tokens by `(+9, -7)`, so `r₁, … , r₃` must be offset by the same
+        // amount. Thus, the adjusted sourcemap will contain the tokens
+        // `c₁ : (17, 23) -> (102, 35)`, `c₂ : (17, 33) -> (102, 50)`, and
+        // `c3 : (18, 3) -> (103, 12)`.
+        //
+        // Or, in diagram form:
+        //
+        //    (17, 23)                                    (position in the edited source file)
+        //    ↓ l
+        //    (8, 30)
+        // (8, 28)        (8, 40)        (9, 10)          (positions in the original source file)
+        // ↓ r₁           ↓ r₂           ↓ r₃
+        // (102, 35)      (102, 50)      (103, 12)        (positions in the target file)
+        //
+        // becomes
+        //
+        //    (17, 23)       (17, 33)       (18, 3)       (positions in the edited source file)
+        //    ↓ c₁           ↓ c₂           ↓ c₃
+        //    (102, 35)      (102, 50)      (103, 12)     (positions in the target file)
+
+        // Helper struct that makes it easier to compare tokens by the start and end
+        // of the range they cover.
+        #[derive(Debug, Clone, Copy)]
+        struct Range<'a> {
+            start: (u32, u32),
+            end: (u32, u32),
+            value: &'a RawToken,
+        }
+
+        /// Turns a list of tokens into a list of ranges, using the provided `key` function to
+        /// determine the order of the tokens.
+        #[allow(clippy::ptr_arg)]
+        fn create_ranges(
+            tokens: &mut [RawToken],
+            key: fn(&RawToken) -> (u32, u32),
+        ) -> Vec<Range<'_>> {
+            tokens.sort_unstable_by_key(key);
+
+            let mut token_iter = tokens.iter().peekable();
+            let mut ranges = Vec::new();
+
+            while let Some(t) = token_iter.next() {
+                let start = key(t);
+                let next_start = token_iter.peek().map_or((u32::MAX, u32::MAX), |t| key(t));
+                // A token extends either to the start of the next token or the end of the line,
+                // whichever comes sooner
+                let end = std::cmp::min(next_start, (start.0, u32::MAX));
+                ranges.push(Range {
+                    start,
+                    end,
+                    value: t,
+                });
+            }
+
+            ranges
+        }
+
+        // Turn `self.tokens` and `adjustment.tokens` into vectors of ranges so we have easy access
+        // to both start and end.
+        // We want to compare `self` and `adjustment` tokens by line/column numbers in the "original
+        // source" file. These line/column numbers are the `dst_line/col` for
+        // the `self` tokens and `src_line/col` for the `adjustment` tokens.
+        let mut self_tokens = std::mem::take(&mut self.tokens);
+        let original_ranges = create_ranges(&mut self_tokens, |t| (t.dst_line, t.dst_col));
+        let mut adjustment_tokens = adjustment.tokens.clone();
+        let adjustment_ranges = create_ranges(&mut adjustment_tokens, |t| (t.src_line, t.src_col));
+
+        let mut original_ranges_iter = original_ranges.iter();
+
+        let mut original_range = match original_ranges_iter.next() {
+            Some(r) => r,
+            None => return,
+        };
+
+        // Iterate over `adjustment_ranges` (sorted by `src_line/col`). For each such range,
+        // consider all `original_ranges` which overlap with it.
+        'outer: for &adjustment_range in &adjustment_ranges {
+            // The `adjustment_range` offsets lines and columns by a certain amount. All
+            // `original_ranges` it covers will get the same offset.
+            let (line_diff, col_diff) = (
+                adjustment_range.value.dst_line as i32 - adjustment_range.value.src_line as i32,
+                adjustment_range.value.dst_col as i32 - adjustment_range.value.src_col as i32,
+            );
+
+            // Skip `original_ranges` that are entirely before the `adjustment_range`.
+            while original_range.end <= adjustment_range.start {
+                match original_ranges_iter.next() {
+                    Some(r) => original_range = r,
+                    None => break 'outer,
+                }
+            }
+
+            // At this point `original_range.end` > `adjustment_range.start`
+
+            // Iterate over `original_ranges` that fall at least partially within the
+            // `adjustment_range`.
+            while original_range.start < adjustment_range.end {
+                // If `original_range` started before `adjustment_range`, cut off the token's start.
+                let (dst_line, dst_col) =
+                    std::cmp::max(original_range.start, adjustment_range.start);
+                let mut token = RawToken {
+                    dst_line,
+                    dst_col,
+                    ..*original_range.value
+                };
+
+                token.dst_line = (token.dst_line as i32 + line_diff) as u32;
+                token.dst_col = (token.dst_col as i32 + col_diff) as u32;
+
+                self.tokens.push(token);
+
+                if original_range.end >= adjustment_range.end {
+                    // There are surely no more `original_ranges` for this `adjustment_range`.
+                    // Break the loop without advancing the `original_range`.
+                    break;
+                } else {
+                    //  Advance the `original_range`.
+                    match original_ranges_iter.next() {
+                        Some(r) => original_range = r,
+                        None => break 'outer,
+                    }
+                }
+            }
+        }
+
+        self.tokens
+            .sort_unstable_by_key(|t| (t.dst_line, t.dst_col));
+    }
+
+    pub fn into_raw_sourcemap(self) -> RawSourceMap<'a> {
+        RawSourceMap {
+            version: Some(3),
+            range_mappings: serialize_range_mappings(&self),
+            mappings: Some(serialize_mappings(&self)),
+            file: self.file,
+            sources: self.sources,
+            source_root: self.source_root,
+            sources_content: self.sources_content,
+            sections: None,
+            names: self.names,
+            ignore_list: self.ignore_list,
+        }
+    }
+}
+
+impl<'a> SourceMapIndex<'a> {
+    pub fn flatten(self) -> Result<SourceMap<'a>> {
+        let mut builder = SourceMapBuilder::new(self.file);
+
+        for section in self.sections {
+            let (off_line, off_col) = section.get_offset();
+
+            let map = match section.map {
+                Some(map) => match decode_common(map.into_data())? {
+                    DecodedMap::Regular(sm) => sm,
+                    DecodedMap::Index(idx) => idx.flatten()?,
+                },
+                None => {
+                    return Err(Error::CannotFlatten(format!(
+                        "Section has an unresolved sourcemap: {}",
+                        section
+                            .url
+                            .map(|v| v.into_data())
+                            .as_deref()
+                            .unwrap_or("<unknown url>")
+                    )));
+                }
+            };
+
+            let sources = map.sources.into_data();
+            let source_contents = map.sources_content.into_data();
+            let ignore_list = map.ignore_list.unwrap_or_default().into_data();
+
+            let mut src_id_map = Vec::<u32>::with_capacity(sources.len());
+
+            for (original_id, (source, contents)) in
+                sources.into_iter().zip(source_contents).enumerate()
+            {
+                debug_assert_eq!(original_id, src_id_map.len());
+                let src_id = builder.add_source(source);
+
+                src_id_map.push(src_id);
+
+                if let Some(contents) = contents {
+                    builder.set_source_contents(src_id, Some(contents));
+                }
+            }
+
+            let names = map.names.into_data();
+            let mut name_id_map = Vec::<u32>::with_capacity(names.len());
+
+            for (original_id, name) in names.into_iter().enumerate() {
+                debug_assert_eq!(original_id, name_id_map.len());
+                let name_id = builder.add_name(name);
+                name_id_map.push(name_id);
+            }
+
+            for token in map.tokens {
+                let dst_col = if token.dst_line == 0 {
+                    token.dst_col + off_col
+                } else {
+                    token.dst_col
+                };
+
+                // Use u32 -> u32 map instead of using the hash map in SourceMapBuilder for better
+                // performance
+                let original_src_id = token.src_id;
+                let src_id = if original_src_id == !0 {
+                    None
+                } else {
+                    src_id_map.get(original_src_id as usize).copied()
+                };
+
+                let original_name_id = token.name_id;
+                let name_id = if original_name_id == !0 {
+                    None
+                } else {
+                    name_id_map.get(original_name_id as usize).copied()
+                };
+
+                let raw = builder.add_raw(
+                    token.dst_line + off_line,
+                    dst_col,
+                    token.src_line,
+                    token.src_col,
+                    src_id,
+                    name_id,
+                    token.is_range,
+                );
+
+                if ignore_list.contains(&token.src_id) {
+                    builder.add_to_ignore_list(raw.src_id);
+                }
+            }
+        }
+
+        Ok(builder.into_sourcemap())
+    }
+}
+
+pub fn strip_junk_header(slice: &[u8]) -> io::Result<&[u8]> {
+    if slice.is_empty() || !is_junk_json(slice[0]) {
+        return Ok(slice);
+    }
+    let mut need_newline = false;
+    for (idx, &byte) in slice.iter().enumerate() {
+        if need_newline && byte != b'\n' {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "expected newline",
+            ))?
+        } else if is_junk_json(byte) {
+            continue;
+        } else if byte == b'\r' {
+            need_newline = true;
+        } else if byte == b'\n' {
+            return Ok(&slice[idx..]);
+        }
+    }
+    Ok(&slice[slice.len()..])
+}
+
+fn is_junk_json(byte: u8) -> bool {
+    byte == b')' || byte == b']' || byte == b'}' || byte == b'\''
+}
+
+/// Decodes range mappping bitfield string into index
+fn decode_rmi(rmi_str: &str, val: &mut BitVec<u8, Lsb0>) -> Result<()> {
+    val.clear();
+    val.resize(rmi_str.len() * 6, false);
+
+    for (idx, &byte) in rmi_str.as_bytes().iter().enumerate() {
+        let byte = match byte {
+            b'A'..=b'Z' => byte - b'A',
+            b'a'..=b'z' => byte - b'a' + 26,
+            b'0'..=b'9' => byte - b'0' + 52,
+            b'+' => 62,
+            b'/' => 63,
+            _ => {
+                return Err(Error::InvalidBase64(byte as char));
+            }
+        };
+
+        val[6 * idx..6 * (idx + 1)].store_le::<u8>(byte);
+    }
+
+    Ok(())
+}
+
+const B64_CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+pub(crate) fn encode_vlq(out: &mut String, num: i64) {
+    let mut num = if num < 0 { ((-num) << 1) + 1 } else { num << 1 };
+
+    loop {
+        let mut digit = num & 0b11111;
+        num >>= 5;
+        if num > 0 {
+            digit |= 1 << 5;
+        }
+        out.push(B64_CHARS[digit as usize] as char);
+        if num == 0 {
+            break;
+        }
+    }
+}
+
+fn encode_vlq_diff(out: &mut String, a: u32, b: u32) {
+    encode_vlq(out, i64::from(a) - i64::from(b))
+}
+
+fn encode_rmi(out: &mut Vec<u8>, data: &[u8]) {
+    fn encode_byte(b: u8) -> u8 {
+        match b {
+            0..=25 => b + b'A',
+            26..=51 => b + b'a' - 26,
+            52..=61 => b + b'0' - 52,
+            62 => b'+',
+            63 => b'/',
+            _ => panic!("invalid byte"),
+        }
+    }
+
+    let bits = data.view_bits::<Lsb0>();
+
+    // trim zero at the end
+    let mut last = 0;
+    for (idx, bit) in bits.iter().enumerate() {
+        if *bit {
+            last = idx;
+        }
+    }
+    let bits = &bits[..last + 1];
+
+    for byte in bits.chunks(6) {
+        let byte = byte.load::<u8>();
+
+        let encoded = encode_byte(byte);
+
+        out.push(encoded);
+    }
+}
+
+fn serialize_range_mappings(sm: &SourceMap) -> Option<String> {
+    let mut buf = Vec::new();
+    let mut prev_line = 0;
+    let mut had_rmi = false;
+    let mut empty = true;
+
+    let mut idx_of_first_in_line = 0;
+
+    let mut rmi_data = Vec::<u8>::new();
+
+    for (idx, token) in sm.tokens.iter().enumerate() {
+        if token.is_range {
+            had_rmi = true;
+            empty = false;
+
+            let num = idx - idx_of_first_in_line;
+
+            rmi_data.resize(rmi_data.len() + 2, 0);
+
+            let rmi_bits = rmi_data.view_bits_mut::<Lsb0>();
+            rmi_bits.set(num, true);
+        }
+
+        while token.dst_line != prev_line {
+            if had_rmi {
+                encode_rmi(&mut buf, &rmi_data);
+                rmi_data.clear();
+            }
+
+            buf.push(b';');
+            prev_line += 1;
+            had_rmi = false;
+            idx_of_first_in_line = idx;
+        }
+    }
+    if empty {
+        return None;
+    }
+
+    if had_rmi {
+        encode_rmi(&mut buf, &rmi_data);
+    }
+
+    Some(String::from_utf8(buf).expect("invalid utf8"))
+}
+
+fn serialize_mappings(sm: &SourceMap) -> String {
+    let mut rv = String::new();
+    // dst == minified == generated
+    let mut prev_dst_line = 0;
+    let mut prev_dst_col = 0;
+    let mut prev_src_line = 0;
+    let mut prev_src_col = 0;
+    let mut prev_name_id = 0;
+    let mut prev_src_id = 0;
+
+    for (idx, token) in sm.tokens.iter().enumerate() {
+        if token.dst_line != prev_dst_line {
+            prev_dst_col = 0;
+            while token.dst_line != prev_dst_line {
+                rv.push(';');
+                prev_dst_line += 1;
+            }
+        } else if idx > 0 {
+            if Some(&token) == sm.tokens.get(idx - 1).as_ref() {
+                continue;
+            }
+            rv.push(',');
+        }
+
+        encode_vlq_diff(&mut rv, token.dst_col, prev_dst_col);
+        prev_dst_col = token.dst_col;
+
+        if token.src_id != !0 {
+            encode_vlq_diff(&mut rv, token.src_id, prev_src_id);
+            prev_src_id = token.src_id;
+            encode_vlq_diff(&mut rv, token.src_line, prev_src_line);
+            prev_src_line = token.src_line;
+            encode_vlq_diff(&mut rv, token.src_col, prev_src_col);
+            prev_src_col = token.src_col;
+            if token.name_id != !0 {
+                encode_vlq_diff(&mut rv, token.name_id, prev_name_id);
+                prev_name_id = token.name_id;
+            }
+        }
+    }
+
+    rv
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ mod errors;
 mod hermes;
 mod js_identifiers;
 mod jsontypes;
+pub mod lazy;
 mod sourceview;
 mod types;
 mod utils;

--- a/src/sourceview.rs
+++ b/src/sourceview.rs
@@ -128,7 +128,7 @@ impl<'a> Iterator for Lines<'a> {
 /// This type is used to implement fairly efficient source mapping
 /// operations.
 pub struct SourceView {
-    source: Arc<str>,
+    pub(crate) source: Arc<str>,
     processed_until: AtomicUsize,
     lines: Mutex<Vec<&'static str>>,
 }


### PR DESCRIPTION
In case of most transforms (for ECMAScript), the original input source map is used only to adjust mappings, and other fields are kept intact.

The _lazy_ variant source maps are source maps used only to call `adjust_mappings`. It does not deserialize everything. Instead, it only deserializes the fields required to calculate the new mappings.

This is done in the name of the performance, and the justification for introducing a new type is at https://github.com/vercel/next.js/pull/80177#issuecomment-2941464441 
<img width="881" alt="image" src="https://github.com/user-attachments/assets/7ca4b084-ba46-4384-ac25-fefeae0e2513" />

